### PR TITLE
killing 1/2 of our costs

### DIFF
--- a/script/assets-generator.sh
+++ b/script/assets-generator.sh
@@ -24,10 +24,10 @@ read -r -d $'\0' METADATA <<-EOM
 }
 EOM
 
-ITEMS="30"
-NAME_PASSED="Backyard Pickleball"
-SYMBOL="BKPB"
-DESCRIPTION="Inaugural Charity Event"
+ITEMS="5"
+NAME_PASSED="Saga Launch"
+SYMBOL="SAGA"
+DESCRIPTION="Saga launch event"
 ANIMATION="1"
 ATTRIBUTES="[{\"trait_type\": \"Orientation\", \"value\": \"Spinning\"}],"
 EXT="png"
@@ -35,17 +35,21 @@ for ((i = 0; i < $ITEMS; i++));
 do
     J=$(($i + 1))
     NAME="$NAME_PASSED #$J"
-    MEDIA_NAME="$i.$EXT"
+    MEDIA_NAME="media.$EXT"
     MEDIA_TYPE="image/$EXT"
     ANIMATION_URL=","
     ANIMATION_FILE="],"
     CATEGORY="image"
-    cp "$ASSETS_DIR/collection.$EXT" "$ASSETS_DIR/$i.$EXT"
     if [ "$ANIMATION" = 1 ]; then
-        cp "$ASSETS_DIR/collection.mp4" "$ASSETS_DIR/$i.mp4"
-        ANIMATION_URL=",\n\t\"animation_url\": \"$i.mp4\","
-        ANIMATION_FILE=",\n\t\t{\n\t\t\t\"uri\": \"$i.mp4\",\n\t\t\t\"type\": \"video/mp4\"\n\t\t}],"
+        # cp "$ASSETS_DIR/collection.mp4" "$ASSETS_DIR/$i.mp4"
+        ANIMATION_URL=",\n\t\"animation_url\": \"media.mp4\","
+        ANIMATION_FILE=",\n\t\t{\n\t\t\t\"uri\": \"media.mp4\",\n\t\t\t\"type\": \"video/mp4\"\n\t\t}],"
         CATEGORY="video"
     fi
     printf "$METADATA" "$NAME" "$SYMBOL" "$DESCRIPTION" "$MEDIA_NAME" "$ANIMATION_URL" "$ATTRIBUTES" "$MEDIA_NAME" "$MEDIA_TYPE" "$ANIMATION_FILE" "$CATEGORY" > "$ASSETS_DIR/$i.json"
 done
+
+if [ "$ANIMATION" = 1 ]; then
+mv "$ASSETS_DIR/collection.mp4" "$ASSETS_DIR/media.mp4"
+fi
+cp "$ASSETS_DIR/collection.$EXT" "$ASSETS_DIR/media.$EXT"

--- a/script/assets-generator.sh
+++ b/script/assets-generator.sh
@@ -24,7 +24,7 @@ read -r -d $'\0' METADATA <<-EOM
 }
 EOM
 
-ITEMS="5"
+ITEMS="1000"
 NAME_PASSED="Saga Launch"
 SYMBOL="SAGA"
 DESCRIPTION="Saga launch event"

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -20,7 +20,7 @@ use mpl_token_metadata::state;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::config::errors::*;
-
+#[derive(Debug)]
 pub struct SugarConfig {
     pub keypair: Keypair,
     pub rpc_url: String,

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -430,7 +430,10 @@ pub async fn mint(
             recent_blockhashes: sysvar::recent_blockhashes::ID,
             instruction_sysvar_account: sysvar::instructions::ID,
         })
-        .args(nft_instruction::MintNft { creator_bump });
+        .args(nft_instruction::MintNft {
+            creator_bump,
+            uri: String::from(""),
+        });
 
     // Add additional accounts directly to the mint instruction otherwise it won't work.
     if !additional_accounts.is_empty() {

--- a/src/upload/process.rs
+++ b/src/upload/process.rs
@@ -28,7 +28,7 @@ pub struct UploadArgs {
     pub cache: String,
     pub interrupted: Arc<AtomicBool>,
 }
-
+#[derive(Debug)]
 pub struct AssetType {
     pub image: Vec<isize>,
     pub metadata: Vec<isize>,
@@ -227,7 +227,7 @@ pub async fn process_upload(args: UploadArgs) -> Result<()> {
 
         if !indices.image.is_empty() {
             errors.extend(
-                upload_data(
+                upload_media(
                     &sugar_config,
                     &asset_pairs,
                     &mut cache,
@@ -263,7 +263,7 @@ pub async fn process_upload(args: UploadArgs) -> Result<()> {
 
         if !indices.animation.is_empty() {
             errors.extend(
-                upload_data(
+                upload_media(
                     &sugar_config,
                     &asset_pairs,
                     &mut cache,
@@ -302,6 +302,7 @@ pub async fn process_upload(args: UploadArgs) -> Result<()> {
             }
         );
 
+        println!("\n\nMETADATA {:#?}\n\n", indices.metadata);
         if !indices.metadata.is_empty() {
             errors.extend(
                 upload_data(
@@ -410,6 +411,126 @@ pub async fn process_upload(args: UploadArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+// uploads one image and animation for n tickets instead of upload_data's n images and n animtions
+async fn upload_media(
+    sugar_config: &SugarConfig,
+    asset_pairs: &HashMap<isize, AssetPair>,
+    cache: &mut Cache,
+    indices: &[isize],
+    data_type: DataType,
+    uploader: &dyn Uploader,
+    interrupted: Arc<AtomicBool>,
+) -> Result<Vec<UploadError>> {
+    let mut extension = HashSet::with_capacity(1);
+    let mut paths = Vec::new();
+    for index in indices {
+        let item = match asset_pairs.get(index) {
+            Some(asset_index) => asset_index,
+            None => return Err(anyhow::anyhow!("Failed to get asset at index {}", index)),
+        };
+        // chooses the file path based on the data type
+        let file_path = match data_type {
+            DataType::Image => item.image.clone(),
+            DataType::Animation => {
+                if let Some(animation) = item.animation.clone() {
+                    animation
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Missing animation path for asset at index {}",
+                        index
+                    ));
+                }
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Expected media file type received {:?}",
+                    data_type
+                ))
+            }
+        };
+
+        let path = Path::new(&file_path);
+        let ext = path
+            .extension()
+            .and_then(OsStr::to_str)
+            .expect("Failed to convert extension from unicode");
+        extension.insert(String::from(ext));
+
+        // image and animation paths are identical
+        if !paths.contains(&file_path) {
+            paths.push(file_path);
+        }
+    }
+    // validates that all files have the same extension
+    let extension = if extension.len() == 1 {
+        extension.iter().next().unwrap()
+    } else {
+        return Err(anyhow!("Invalid file extension: {:?}", extension));
+    };
+
+    // validates at most 2 files (media and collection)
+    if paths.len() > 2 {
+        return Err(anyhow!("Invalid file extension: {:?}", extension));
+    };
+
+    let content_type = match data_type {
+        DataType::Image => format!("image/{}", extension),
+        DataType::Animation => format!("video/{}", extension),
+        DataType::Metadata => {
+            return Err(anyhow::anyhow!(
+                "Expected media file type received {:?}",
+                data_type
+            ))
+        }
+    };
+
+    println!("\nSending data: (Ctrl+C to abort)");
+
+    let pb = progress_bar_with_style(paths.len() as u64);
+
+    let mut assets = Vec::new();
+    // get cache items
+    for file_path in paths {
+        // path to the media/metadata file
+        let path = Path::new(&file_path);
+        let file_name = String::from(
+            path.file_name()
+                .and_then(OsStr::to_str)
+                .expect("Filed to get file name."),
+        );
+        let item = get_cache_item_new(path, cache)?;
+
+        assets.push(AssetInfo {
+            asset_id: item.0,
+            name: file_name.clone(),
+            content: file_path.clone(),
+            data_type: data_type.clone(),
+            content_type: content_type.clone(),
+        });
+    }
+    let errors = uploader
+        .upload(
+            sugar_config,
+            cache,
+            data_type,
+            &mut assets,
+            &pb,
+            interrupted,
+        )
+        .await?;
+
+    if !errors.is_empty() {
+        pb.abandon_with_message(format!("{}", style("Upload failed ").red().bold()));
+    } else {
+        pb.finish_with_message(format!("{}", style("Upload successful ").green().bold()));
+    }
+
+    // makes sure the cache file is updated
+    cache.sync_file()?;
+
+    Ok(errors)
 }
 
 /// Upload the data to the selected storage.

--- a/src/upload/process.rs
+++ b/src/upload/process.rs
@@ -302,7 +302,6 @@ pub async fn process_upload(args: UploadArgs) -> Result<()> {
             }
         );
 
-        println!("\n\nMETADATA {:#?}\n\n", indices.metadata);
         if !indices.metadata.is_empty() {
             errors.extend(
                 upload_data(

--- a/src/upload/uploader.rs
+++ b/src/upload/uploader.rs
@@ -37,6 +37,7 @@ pub const MOCK_URI_SIZE: usize = 100;
 /// file system. In the case of json metadata files, the `content` contains the string
 /// representation of the json metadata.
 ///
+#[derive(Debug)]
 pub struct AssetInfo {
     /// Id of the asset in the cache.
     pub asset_id: String,
@@ -198,68 +199,146 @@ impl<T: ParallelUploader> Uploader for T {
         interrupted: Arc<AtomicBool>,
     ) -> Result<Vec<UploadError>> {
         let mut handles = Vec::new();
-
         for task in assets.drain(0..cmp::min(assets.len(), PARALLEL_LIMIT)) {
             handles.push(self.upload_asset(task));
         }
-
         let mut errors = Vec::new();
-
-        while !interrupted.load(Ordering::SeqCst) && !handles.is_empty() {
-            match select_all(handles).await {
-                (Ok(res), _index, remaining) => {
-                    // independently if the upload was successful or not
-                    // we continue to try the remaining ones
-                    handles = remaining;
-                    if res.is_ok() {
-                        let val = res?;
-                        let link = val.clone().1;
-                        // cache item to update
-                        let item = cache.items.0.get_mut(&val.0).unwrap();
-                        match data_type {
-                            DataType::Image => item.image_link = link,
-                            DataType::Metadata => item.metadata_link = link,
-                            DataType::Animation => item.animation_link = Some(link),
+        // only upload n times for DataType::Metadata, DataType::Image and DataType::Animation get
+        // uploaded once but set to cache item n times
+        return match data_type {
+            DataType::Metadata => {
+                while !interrupted.load(Ordering::SeqCst) && !handles.is_empty() {
+                    match select_all(handles).await {
+                        (Ok(res), _index, remaining) => {
+                            // independently if the upload was successful or not
+                            // we continue to try the remaining ones
+                            handles = remaining;
+                            if res.is_ok() {
+                                let val = res?;
+                                let link = val.clone().1;
+                                // cache item to update
+                                let item = cache.items.0.get_mut(&val.0).unwrap();
+                                item.metadata_link = link;
+                                // updates the progress bar
+                                progress.inc(1);
+                            } else {
+                                // user will need to retry the upload
+                                errors.push(UploadError::SendDataFailed(format!(
+                                    "Upload error: {:?}",
+                                    res.err().unwrap()
+                                )));
+                            }
                         }
-                        // updates the progress bar
-                        progress.inc(1);
-                    } else {
-                        // user will need to retry the upload
-                        errors.push(UploadError::SendDataFailed(format!(
-                            "Upload error: {:?}",
-                            res.err().unwrap()
-                        )));
+                        (Err(err), _index, remaining) => {
+                            errors.push(UploadError::SendDataFailed(format!(
+                                "Upload error: {:?}",
+                                err
+                            )));
+                            // ignoring all errors
+                            handles = remaining;
+                        }
+                    }
+                    if !assets.is_empty() {
+                        // if we are half way through, let spawn more transactions
+                        if (PARALLEL_LIMIT - handles.len()) > (PARALLEL_LIMIT / 2) {
+                            // syncs cache (checkpoint)
+                            cache.sync_file()?;
+                            for task in assets.drain(0..cmp::min(assets.len(), PARALLEL_LIMIT / 2))
+                            {
+                                handles.push(self.upload_asset(task));
+                            }
+                        }
                     }
                 }
-                (Err(err), _index, remaining) => {
-                    errors.push(UploadError::SendDataFailed(format!(
-                        "Upload error: {:?}",
-                        err
-                    )));
-                    // ignoring all errors
-                    handles = remaining;
+
+                if errors.is_empty() && !assets.is_empty() {
+                    progress
+                        .abandon_with_message(format!("{}", style("Upload aborted ").red().bold()));
+                    return Err(UploadError::SendDataFailed(
+                        "Not all files were uploaded.".to_string(),
+                    )
+                    .into());
                 }
+
+                Ok(errors)
             }
-            if !assets.is_empty() {
-                // if we are half way through, let spawn more transactions
-                if (PARALLEL_LIMIT - handles.len()) > (PARALLEL_LIMIT / 2) {
-                    // syncs cache (checkpoint)
-                    cache.sync_file()?;
-                    for task in assets.drain(0..cmp::min(assets.len(), PARALLEL_LIMIT / 2)) {
-                        handles.push(self.upload_asset(task));
+            _ => {
+                while !interrupted.load(Ordering::SeqCst) && !handles.is_empty() {
+                    match select_all(handles).await {
+                        (Ok(res), _index, remaining) => {
+                            // independently if the upload was successful or not
+                            // we continue to try the remaining ones
+                            handles = remaining;
+                            if res.is_ok() {
+                                let val = res?;
+                                let link = val.clone().1;
+                                // cache item to update
+                                if val.0 == "-1" {
+                                    let item = cache.items.0.get_mut(&val.0).unwrap();
+                                    match data_type {
+                                        DataType::Image => item.image_link = link,
+                                        DataType::Animation => item.animation_link = Some(link),
+                                        DataType::Metadata => (),
+                                    }
+                                } else {
+                                    // loop through all chached items and set image/animation link
+                                    for i in 0..cache.items.len() - 1 {
+                                        let item =
+                                            cache.items.0.get_mut(&format!("{}", i)[..]).unwrap();
+                                        let cloned_link = link.clone();
+                                        match data_type {
+                                            DataType::Image => item.image_link = cloned_link,
+                                            DataType::Animation => {
+                                                item.animation_link = Some(cloned_link)
+                                            }
+                                            DataType::Metadata => (),
+                                        }
+                                    }
+                                }
+                                // updates the progress bar
+                                progress.inc(1);
+                            } else {
+                                // user will need to retry the upload
+                                errors.push(UploadError::SendDataFailed(format!(
+                                    "Upload error: {:?}",
+                                    res.err().unwrap()
+                                )));
+                            }
+                        }
+                        (Err(err), _index, remaining) => {
+                            errors.push(UploadError::SendDataFailed(format!(
+                                "Upload error: {:?}",
+                                err
+                            )));
+                            // ignoring all errors
+                            handles = remaining;
+                        }
+                    }
+                    if !assets.is_empty() {
+                        // if we are half way through, let spawn more transactions
+                        if (PARALLEL_LIMIT - handles.len()) > (PARALLEL_LIMIT / 2) {
+                            // syncs cache (checkpoint)
+                            cache.sync_file()?;
+                            for task in assets.drain(0..cmp::min(assets.len(), PARALLEL_LIMIT / 2))
+                            {
+                                handles.push(self.upload_asset(task));
+                            }
+                        }
                     }
                 }
+
+                if errors.is_empty() && !assets.is_empty() {
+                    progress
+                        .abandon_with_message(format!("{}", style("Upload aborted ").red().bold()));
+                    return Err(UploadError::SendDataFailed(
+                        "Not all files were uploaded.".to_string(),
+                    )
+                    .into());
+                }
+
+                Ok(errors)
             }
-        }
-
-        if errors.is_empty() && !assets.is_empty() {
-            progress.abandon_with_message(format!("{}", style("Upload aborted ").red().bold()));
-            return Err(
-                UploadError::SendDataFailed("Not all files were uploaded.".to_string()).into(),
-            );
-        }
-
-        Ok(errors)
+        };
     }
 }
 

--- a/src/validate/process.rs
+++ b/src/validate/process.rs
@@ -114,7 +114,6 @@ pub fn process_validate(args: ValidateArgs) -> Result<()> {
                 return;
             }
         };
-        println!("{:?}", metadata);
         // To be replaced with the strict validator once JSON standard is finalized.
         if args.strict {
             match metadata.validate() {


### PR DESCRIPTION
**Before this branch:**
1) get assets for NFT, usually image and animation, from artist
2) copy the assets n times for n tickets
3) upload and pay fees for n tickets images/animations

**After this branch:**
1) same as above
2) we dont copy assets, instead set image/animation reference of n tickets to the same asset
3) upload single animation and image files

Test plan:
Ran candy machine on devnet with 5 tickets. Completed successfully:
Candy machine ID: 2sPqgSp2eDFuD7NjbZ3RDyDXxeEaA5TggXpSbB4HjWKT
Collection mint ID: 9yYULHwLG9zxGHw4KkTNCdzXLnqvf2qFiEEdDeTLrsJK
I went to soleyes [url](https://www.solaneyes.com/address/2sPqgSp2eDFuD7NjbZ3RDyDXxeEaA5TggXpSbB4HjWKT?cluster=devnet)
under the "Account Info" tab where u can see account data. Opened 2 random metadata: [1](https://w2mlmpybioijaxvc54zmvnepqxpjilmxzsozabcas6s4jzwvdcvq.arweave.net/tpi2PwFDkJBeou8yyrSPhd6ULZfMnZAEQJelxObVGKs) and [2](https://5mi3jcbp7d2g4lkdfsru2bwmskt5igkjpbabxqdqhkrbdxde47ua.arweave.net/6xG0iC_49G4tQyyjTQbMkqfUGUl4QBvAcDqiEdxk5-g)

Notice how everything is the same but the NFT names.

When sugar is running, u can also see that we upload 2 image (one for collection, one for all NFT tickets), 1 animation (collection doesn't need animation), and 5 metadata

**Next Steps**
- Add supabase uploader as an upload method
- Replace metadata URL with supabase